### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,6 @@
     "prop-types": "^15.6.0",
     "react-intl": "^2.8.0"
   },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
-  },
   "peerDependencies": {
     "@folio/stripes": "^2.11.1",
     "react": "*"


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.